### PR TITLE
Change scaler and sc to signed chars to allow for negative scaler value in OBIS message

### DIFF
--- a/src/sml.cpp
+++ b/src/sml.cpp
@@ -28,7 +28,7 @@ static sml_states_t currentState = SML_START;
 static char nodes[MAX_TREE_SIZE];
 static unsigned char currentLevel = 0;
 static unsigned short crc = 0xFFFF;
-static char sc;
+static signed char sc;
 static unsigned short crcMine = 0xFFFF;
 static unsigned short crcReceived = 0x0000;
 static unsigned char len = 4;
@@ -221,7 +221,7 @@ void smlOBISManufacturer(unsigned char * str, int maxSize) {
   }
 }
 
-void pow(double &val, char &scaler) {
+void pow(double &val, signed char &scaler) {
   if( scaler < 0 ) {
     while( scaler++ ) {
       val /= 10;
@@ -234,7 +234,7 @@ void pow(double &val, char &scaler) {
   }
 }
 
-void smlOBISByUnit(long int & val, char & scaler, sml_units_t unit) {
+void smlOBISByUnit(long int & val, signed char & scaler, sml_units_t unit) {
   unsigned char i = 0, pos = 0, size = 0;
   val = -1; /* unknown or error */
   while (i < listPos) {

--- a/src/sml.h
+++ b/src/sml.h
@@ -91,7 +91,7 @@ typedef enum  {
 sml_states_t smlState (unsigned char & byte);
 bool smlOBISCheck(const unsigned char * obis);
 void smlOBISManufacturer(unsigned char * str, int maxSize);
-void smlOBISByUnit(double & wh, char & scaler, sml_units_t unit);
+void smlOBISByUnit(double & wh, signed char & scaler, sml_units_t unit);
 
 // Be aware that double on Arduino UNO is just 32 bit
 void smlOBISWh(double & wh);


### PR DESCRIPTION
Hi Oliver,

Thank you very much for your library. This saved me hours of coding this myself. 

I just found a small issue on the scaler values which might or might not have to do with my meter (MT175) implementation. 

After the PIN code is entered on the meter, the wh are output in higher precision and a scale factor of -1. This would translate to 0xff in an unsigned char with which the pow() function will go crazy.

I changed the scaler and sc variables to unsigned which fixes the issue and correctly sets the scaler to -1 instead of 255:

...
LISTSTART on level 5 with 7 nodes
 Data 7 (length = 6): 01 00 01 08 01 FF 
 Data 6 (empty)
 Data 5 (empty)
 Data 4 (length = 1): 1E 
 Data 3 (length = 1): FF 
 Data 2 (length = 8): 00 00 00 00 03 B1 11 97 
 Data 1 (empty)

Successfully received a complete message!
 Power T1    (1-0:1.8.1)..: 6193602.300 kWh
 Power T1+T2 (1-0:1.8.0)..: 6193602.300 kWh
...

Thanks again and best regards,

(also) Oliver.
