### PR TITLE
Add parsing of two-byte twos' complement message payloads.

### DIFF
--- a/src/sml.cpp
+++ b/src/sml.cpp
@@ -301,6 +301,12 @@ void smlOBISByUnit(long int &val, signed char &scaler, sml_units_t unit)
     }
     if (pos == 6) {
       size = (int)listBuffer[i];
+      if (size == 2) {
+        /* 16 bit - with sign extension for twos' complement values */
+        int16_t signedTwoByteValue =
+            (int16_t)listBuffer[i + 1] << 8 | listBuffer[i + 2];
+        val = (long int)signedTwoByteValue;
+      }
       if (size == 4) {
         /* 32 bit */
         val = (long int)listBuffer[i + 1] << 24 |


### PR DESCRIPTION
When observing the current power value and running a energy production unit (e.g., solar power on your own roof), it appears that in at least some meters the current power value is provided as a two-byte value in twos' complement representation (to be fully verified).

This change lets SML Parser parse two-byte values. In addition, it performs sign extension in case of negative values.