### PR TITLE
Extended list not working with itron eHz metering device

### DIFF
--- a/src/sml.h
+++ b/src/sml.h
@@ -101,5 +101,6 @@ void smlOBISByUnit(long long int &wh, signed char &scaler, sml_units_t unit);
 void smlOBISWh(double &wh);
 void smlOBISW(double &w);
 void smlOBISVolt(double &v);
+void smlOBISAmpere(double &a);
 
 #endif


### PR DESCRIPTION
Changed handling of TL extended according to: https://www.bsi.bund.de/SharedDocs/Downloads/DE/BSI/Publikationen/TechnischeRichtlinien/TR03109/TR-03109-1_Anlage_Feinspezifikation_Drahtgebundene_LMN-Schnittstelle_Teilb.pdf?__blob=publicationFile&v=1

To be checked, but works like this with my meter.

![image](https://user-images.githubusercontent.com/8700196/209989612-5b4b335c-e699-4a89-a7e5-082bc7e1086c.png)

Added "Ampere" conversion function